### PR TITLE
Add variable to insert inline namespace scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Contributions are welcome
 
 {namespaceTab} - automatic namespace content tabulation. If there is no namespace, no tab will be added
 
+{namespaceScope} - inline namespace scope is `NamespaceName::`
+
 {className} - specified class name
 
 {headerFileName} - specified name with header extension

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,10 +65,12 @@ class FileFactory {
 			result = result.replace(/{namespaceStart}/g, `namespace ${this.namespaceName} {`);
 			result = result.replace(/{namespaceEnd}/g, `} // ${this.namespaceName}`);
 			result = result.replace(/{namespaceTab}/g, "\t");
+			result = result.replace(/{namespaceScope}/g, `${this.namespaceName}::`);
 		} else {
 			result = result.replace(/{namespaceStart}/g, "");
 			result = result.replace(/{namespaceEnd}/g, "");
 			result = result.replace(/{namespaceTab}/g, "");
+			result = result.replace(/{namespaceScope}/g, "");
 		}
 		result = result.replace(/{className}/g, this.className);
 		result = result.replace(/{headerFileName}/g, this.headerName);


### PR DESCRIPTION
Example of usage:
```json
"cpp-class-generator.templates.header": [
    "/**",
    " * @file {headerFileName}",
    " * @author {userName}",
    " * @date {date}",
    " *",
    " * @copyright {copyright}",
    " *",
    " */",
    "",
    "#pragma once",
    "",
    "{namespaceStart}",
    "{namespaceTab}class {className} {",
    "{namespaceTab}public:",
    "{namespaceTab}{className}();",
    "{namespaceTab}~{className}();",
    "{namespaceTab}};",
    "{namespaceEnd}"
],
"cpp-class-generator.templates.source": [
    "#include \"{headerFileName}\"",
    "",
    "{namespaceScope}{className}::{className}(){",
    "}",
    "",
    "{namespaceScope}{className}::~{className}(){",
    "}"
]
```

Replaced to:

header
```c++
/**
 * @file header.h
 * @author User
 * @date 2023-05-15
 *
 * @copyright COMPANY NAME
 *
 */

#pragma once

namespace NamespaceName {
	class ClassName {
	public:
	ClassName();
	~ClassName();
	};
} // NamespaceName
```

source
```c++
#include "header.h"

NamespaceName::ClassName::ClassName(){
}

NamespaceName::ClassName::~ClassName(){
}
```