### PR TITLE
Remove empty lines, when namespace name not present

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,8 +67,8 @@ class FileFactory {
 			result = result.replace(/{namespaceTab}/g, "\t");
 			result = result.replace(/{namespaceScope}/g, `${this.namespaceName}::`);
 		} else {
-			result = result.replace(/{namespaceStart}/g, "");
-			result = result.replace(/{namespaceEnd}/g, "");
+			result = result.replace(/{namespaceStart}\r?\n?/g, "");
+			result = result.replace(/\r?\n?{namespaceEnd}(\r?\n?)/g, "$1");
 			result = result.replace(/{namespaceTab}/g, "");
 			result = result.replace(/{namespaceScope}/g, "");
 		}


### PR DESCRIPTION
In current case, template
```json
"cpp-class-generator.templates.header": [
    "/**",
    " * @file {headerFileName}",
    " * @author {userName}",
    " * @date {date}",
    " *",
    " * @copyright {copyright}",
    " *",
    " */",
    "",
    "#pragma once",
    "",
    "{namespaceStart}",
    "{namespaceTab}class {className} {",
    "{namespaceTab}public:",
    "{namespaceTab}{className}();",
    "{namespaceTab}~{className}();",
    "{namespaceTab}};",
    "{namespaceEnd}"
]
```

Generate next header for empty namespace name:
```cpp
/**
 * @file header.h
 * @author User
 * @date 2023-05-15
 *
 * @copyright COMPANY NAME
 *
 */

#pragma once


class ClassName {
public:
ClassName();
~ClassName();
};
// I'm added here comment, because GH hide this line, when she is empty
```

This PR changes regular expression, to remove empty lines leaved from namespace variables.

Header generated with this PR:
```cpp
/**
 * @file header.h
 * @author User
 * @date 2023-05-15
 *
 * @copyright COMPANY NAME
 *
 */

#pragma once

class ClassName {
public:
ClassName();
~ClassName();
};
```