### PR TITLE
Add own template for header-only classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,11 @@
           ],
           "description": "Header file template"
         },
+        "cpp-class-generator.templates.header-only": {
+          "type": "array",
+          "default": [],
+          "description": "File template for header-only classes"
+        },
         "cpp-class-generator.templates.source": {
           "type": "array",
           "default": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,7 +166,8 @@ class FileFactory {
 			FileFactory.ProcessFile(path.path, filename, sourceExt, sourcefile);
 		} else {
 			this.headerName = `${filename}${singleHeaderExt}`;
-			let headerFileTemplate = FileFactory.getTemplateFromConfig("templates.header");
+			let headerFileTemplate = FileFactory.getTemplateFromConfig("templates.header-only");
+			if (headerFileTemplate.length == 0) headerFileTemplate = FileFactory.getTemplateFromConfig("templates.header");
 			let headerfile = this.processString(
 				headerFileTemplate,
 				true);


### PR DESCRIPTION
It's allow use different templates for single-header class and separated header/source class.

When template for single-header class is empty, used template from separated header/source class (to backward compatible with current templates).

This feature required because workspace may contain template with forward declarations for separated header/source class. And when user create single-header class, they must edit this declarations.