### PR TITLE
Allow define multiple class templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
           "description": "Source code file extension"
         },
         "cpp-class-generator.templates.header": {
-          "type": "array",
+          "type": ["array", "object"],
           "default": [
             "{copyright}",
             "#pragma once",
@@ -126,12 +126,12 @@
           "description": "Header file template"
         },
         "cpp-class-generator.templates.header-only": {
-          "type": "array",
+          "type": ["array", "object"],
           "default": [],
           "description": "File template for header-only classes"
         },
         "cpp-class-generator.templates.source": {
-          "type": "array",
+          "type": ["array", "object"],
           "default": [
             "{copyright}",
             "#include \"{headerFileName}\"",


### PR DESCRIPTION
Maybe it out of scope for this extension, but I'm faced with the need to have multiple templates...

With this PR you can define named templates for classes.

Example:
![image](https://github.com/k4li-0x0/cpp-class-generator/assets/12231048/109d9d7d-0c33-4ca2-a70d-32e488492042)
```json
"cpp-class-generator.templates.header-only": {
    "Default":[
        "/**",
        " * @file {headerFileName}",
        " * @author {userName}",
        " * @date {date}",
        " *",
        " * @copyright {copyright}",
        " *",
        " */",
        "",
        "#pragma once",
        "",
        "{namespaceStart}",
        "{namespaceTab}class {className} {",
        "{namespaceTab}};",
        "{namespaceEnd}"
    ],
    "Without copyrights":[
        "#pragma once",
        "",
        "{namespaceStart}",
        "{namespaceTab}class {className} {",
        "{namespaceTab}};",
        "{namespaceEnd}"
    ]
}
```

For separated header/source class, `cpp-class-generator.templates.header` and `cpp-class-generator.templates.source` must have the same template name. Otherwise, you will receive an error notification when creating.

Perhaps it would be better to specify a pair pattern, but I do not know how to do it better. Now the source template is determined by the template that was chosen for the header.