### PR TITLE
Change config architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,38 @@ Contributions are welcome
 
 {headerFileName} - specified name with header extension
 
+## Config example
+
+```json
+"cpp-class-generator.templates": [
+    {
+        "name": "Header-only class",
+        "header": [
+            "{copyright}",
+            "",
+            "#pragma once",
+            "",
+            "{namespaceStart}",
+            "{namespaceTab}class {className} {",
+            "{namespaceTab}};",
+            "{namespaceEnd}"
+        ]
+    },
+    {
+        "name": "Separated source/header class",
+        "header": "Header-only class", // Reference to header in other template
+        "source": [
+            "{copyright}",
+            "",
+            "#include \"{headerFileName}\"",
+            ""
+        ] 
+    }
+]
+```
+
+Configs from global and local settings will be merged - you can add main classes in global settings and project-specific classes in workspace settings, without duplicates.
+
 ## Current version - [v1.0.0] - 05.11.2022 (Release 🥳)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "publisher": "k4li",
   "activationEvents": [
-    "onCommand:cpp-class-generator.createClass"
+    "onStartupFinished"
   ],
   "main": "./out/main.js",
   "contributes": {
@@ -55,7 +55,7 @@
           ],
           "description": "Files copyright"
         },
-        "cpp-class-generator.templates.date-format": {
+        "cpp-class-generator.date-format": {
           "type": "string",
           "enum": [
             "DD-MM-YYYY",
@@ -80,73 +80,68 @@
           "default": "DD.MM.YYYY",
           "description": "File date format"
         },
-        "cpp-class-generator.templates.header-extension": {
-          "type": "string",
-          "enum": [
-            ".h",
-            ".hpp",
-            ".hh"
-          ],
-          "default": ".h",
-          "description": "Header file extension"
-        },
-        "cpp-class-generator.templates.single-header-extension": {
-          "type": "string",
-          "enum": [
-            ".h",
-            ".hpp",
-            ".hh"
-          ],
-          "default": ".hpp",
-          "description": "Single header file extension"
-        },
-        "cpp-class-generator.templates.source-extension": {
-          "type": "string",
-          "enum": [
-            ".cpp",
-            ".cxx",
-            ".cc"
-          ],
-          "default": ".cpp",
-          "description": "Source code file extension"
-        },
-        "cpp-class-generator.templates.header": {
-          "type": ["array", "object"],
-          "default": [
-            "{copyright}",
-            "#pragma once",
-            "",
-            "{namespaceStart}",
-            "{namespaceTab}// {className}",
-            "{namespaceTab}class {className} {",
-            "{namespaceTab}};",
-            "{namespaceEnd}",
-            ""
-          ],
-          "description": "Header file template"
-        },
-        "cpp-class-generator.templates.header-only": {
-          "type": ["array", "object"],
-          "default": [],
-          "description": "File template for header-only classes"
-        },
-        "cpp-class-generator.templates.source": {
-          "type": ["array", "object"],
-          "default": [
-            "{copyright}",
-            "#include \"{headerFileName}\"",
-            ""
-          ],
-          "description": "Source code file template"
-        },
-        "cpp-class-generator.templates.default-file-scheme": {
-          "type": "string",
-          "default": "Separated Header/Source files",
-          "enum": [
-            "Separated Header/Source files",
-            "Single file"
-          ],
-          "description": "Default generated file scheme"
+        "cpp-class-generator.templates": {
+          "type": "array",
+          "scope": "resource",
+          "description": "C++ class file templates",
+          "items": {
+            "type": "object",
+            "description": "C++ class template",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of class template"
+              },
+              "header": {
+                "type": [
+                  "string",
+                  "array"
+                ],
+                "description": "Header content or name of other template"
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "array",
+                  "null"
+                ],
+                "default": null,
+                "description": "Source content or name of other template. When null class is single-header"
+              },
+              "header_extension": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  ".h",
+                  ".hpp",
+                  ".hh",
+                  ".hxx"
+                ],
+                "default": null,
+                "description": "Extension of header file. When null used .h for separated source/header classes and .hpp for single-header classes"
+              },
+              "source_extension": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  ".cpp",
+                  ".cc",
+                  ".cxx",
+                  ".c"
+                ],
+                "default": null,
+                "description": "Extension of source file. When null used .cpp"
+              }
+            },
+            "required": [
+              "name",
+              "header"
+            ]
+          }
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,241 @@
+import * as vscode from 'vscode';
+import { ConfigTemplate, Template } from './template';
+
+export class Config {
+    private templates: Map<string, Template> = new Map();
+    private configChangeDisposable: vscode.Disposable;
+    private dateFormat = "DD.MM.YYYY";
+    private userName: string | null = null;
+    private copyright = [
+        "//",
+        "// Created by {userName} on {date} ",
+        "//"
+    ];
+
+    constructor() {
+        this.reload();
+        this.configChangeDisposable = vscode.workspace.onDidChangeConfiguration(this.onChangeConfiguration, this);
+    }
+
+    private async onChangeConfiguration(e: vscode.ConfigurationChangeEvent): Promise<void> {
+        if (e.affectsConfiguration('cpp-class-generator'))
+            await this.reload();
+    }
+
+    dispose(): void {
+        this.configChangeDisposable.dispose();
+    }
+
+    private async readConfig(): Promise<void> {
+        const config = vscode.workspace.getConfiguration('cpp-class-generator');
+
+        this.dateFormat = config.get('date-format', this.dateFormat);
+        this.copyright = config.get<Array<string>>('project.copyright', this.copyright);
+        this.userName = config.get('user.name', this.userName);
+
+        this.templates.clear();
+        // Merge global and local configs
+        await this.loadTemplates(vscode.ConfigurationTarget.Global)
+        await this.loadTemplates(vscode.ConfigurationTarget.Workspace)
+        await this.loadTemplates(vscode.ConfigurationTarget.WorkspaceFolder)
+
+        // Add default templates
+        if (this.templates.size == 0) {
+            const singleHeader: Template = {
+                header: ["{copyright}", "#pragma once", "", "{namespaceStart}", "{namespaceTab}class {className}{};", "{namespaceEnd}"]
+            };
+            this.templates.set("Single file", singleHeader);
+
+            const separated: Template = {
+                header: "Single file",
+                source: ["{copyright}", "#include \"{headerFileName}\"", ""]
+            };
+            this.templates.set("Separated Header/Source files", separated);
+        }
+    }
+
+    private async loadTemplates(scope: vscode.ConfigurationTarget): Promise<void> {
+        let config = vscode.workspace.getConfiguration('cpp-class-generator');
+        const getConfig = (name: string, defaultValue?: any) => {
+            const values = config.inspect(name);
+            if (values === undefined) return defaultValue;
+            if (scope == vscode.ConfigurationTarget.Global)
+                return values.globalValue || defaultValue;
+            else if (scope == vscode.ConfigurationTarget.Workspace)
+                return values.workspaceValue || defaultValue;
+            else if (scope == vscode.ConfigurationTarget.WorkspaceFolder)
+                return values.workspaceFolderValue || defaultValue;
+        };
+        const templates = getConfig('templates') as Object;
+        if (templates === undefined || !templates.hasOwnProperty('length') || (templates as Array<ConfigTemplate>).length == 0) {
+            // Backward compatible - load old templates
+            let headerExtension = getConfig('templates.header-extension', ".h");
+            let singleHeaderExtension = getConfig('templates.single-header-extension', ".hpp");
+            let sourceExtension = getConfig('templates.source-extension', ".cpp");
+            const singleHeader = getConfig('templates.header-only');
+            let old_templates: Map<string, Template> = new Map();
+            if (singleHeader !== null && singleHeader !== undefined) {
+                if (Array.isArray(singleHeader)) {
+                    const templ: Template = {
+                        header: (singleHeader as Array<string>)
+                    };
+                    old_templates.set("Imported (single-header)", templ);
+                } else {
+                    let templates = new Map<string, Array<string>>(Object.entries(singleHeader as Object));
+                    Array.from(templates.keys()).forEach(name => {
+                        let header = templates.get(name);
+                        if (header === null || header === undefined) return;
+                        const templ: Template = {
+                            header: header,
+                            header_extension: singleHeaderExtension
+                        };
+                        old_templates.set(`${name} (single-header)`, templ);
+                    })
+                }
+            }
+            const header = getConfig('templates.header');
+            if (header !== null && header !== undefined) {
+                if (Array.isArray(header)) {
+                    const source = getConfig('templates.source');
+                    if (Array.isArray(source)) {
+                        const templ: Template = {
+                            header: (header as Array<string>),
+                            source: (source as Array<string>)
+                        };
+                        old_templates.set("Imported", templ);
+                    }
+                } else {
+                    let header_templates = new Map<string, Array<any>>(Object.entries(header as Object));
+                    let source_templates = new Map<string, Array<any>>(Object.entries(getConfig('templates.source') as Object));
+                    Array.from(header_templates.keys()).forEach(name => {
+                        let header = header_templates.get(name);
+                        if (header === null || header === undefined) return;
+                        let source = source_templates.get(name);
+                        if (source === null || source === undefined) return;
+                        const templ: Template = {
+                            header: header,
+                            header_extension: headerExtension,
+                            source: source,
+                            source_extension: sourceExtension
+                        };
+                        old_templates.set(name, templ);
+                    })
+                }
+            }
+
+            // Move data-format to new name
+            let dateFormat = getConfig('templates.date-format', "");
+            if (dateFormat !== "") {
+                this.dateFormat = dateFormat;
+                await config.update('date-format', dateFormat, scope);
+            }
+
+            // Convert old configs to new format
+            let arr: Array<ConfigTemplate> = [];
+            for (let [key, value] of old_templates) {
+                const isSingleHeader = value.source === null || value.source === undefined;
+                if (isSingleHeader) {
+                    const templ: ConfigTemplate = {
+                        name: key,
+                        header: value.header,
+                        header_extension: singleHeaderExtension
+                    };
+                    arr.push(templ);
+                } else {
+                    const templ: ConfigTemplate = {
+                        name: key,
+                        header: value.header,
+                        header_extension: headerExtension,
+                        source: value.source,
+                        source_extension: sourceExtension
+                    };
+                    arr.push(templ);
+                }
+                this.templates.set(key, value);
+            }
+            if (arr.length > 0)
+                await config.update('templates', arr, scope);
+        } else {
+            // Load new templates
+            (templates as Array<ConfigTemplate>).forEach(templ => {
+                if (templ.name === null || templ.name === undefined || templ.name.length == 0) {
+                    console.log("cpp-class-generator: skip template without a name");
+                    return;
+                }
+                if (templ.header === null || templ.header === undefined) {
+                    console.log(`cpp-class-generator: skip template ${templ.name} - header not set`);
+                    return;
+                }
+                this.templates.set(templ.name, (templ as Template));
+            });
+        }
+    }
+
+    private async resolveReferences(remove?: string): Promise<void> {
+        if (this.templates.size < 2) return;
+
+        if (remove !== null && remove !== undefined)
+            this.templates.delete(remove);
+
+        for (let [key, value] of this.templates) {
+            let modified = false;
+            if (typeof value.header === 'string') {
+                let rhs = this.templates.get(value.header);
+                if (rhs === undefined) {
+                    console.log(`cpp-class-generator: Template ${value.header} not defined`);
+                    this.resolveReferences(key);
+                    break;
+                }
+                value.header = rhs.header;
+                modified = true;
+            }
+            if (typeof value.source === 'string') {
+                let rhs = this.templates.get(value.source);
+                if (rhs === undefined) {
+                    console.log(`cpp-class-generator: Template ${value.source} not defined`);
+                    this.resolveReferences(key);
+                    break;
+                }
+                value.source = rhs.source;
+                modified = true;
+            }
+            if (modified) {
+                if (typeof value.header === 'string' || typeof value.source === 'string') {
+                    console.log(`cpp-class-generator: Reference to reference not allowed - template ${key} skipped`);
+                    this.resolveReferences(key);
+                    break;
+                }
+                this.templates.set(key, value);
+            }
+        }
+    }
+
+    public async reload() {
+        this.readConfig().then(() => {
+            this.resolveReferences();
+        });
+    }
+
+    public async getTemplate(name: string): Promise<Template | undefined> {
+        return this.templates.get(name);
+    }
+
+    public async getAvailableNames(): Promise<Array<string> | undefined> {
+        if (this.templates.size == 0) return undefined;
+        return Array.from(this.templates.keys());
+    }
+
+    public getDateFormat(): string {
+        return this.dateFormat;
+    }
+
+    public getUserName(): string {
+        if (typeof this.userName === 'string')
+            return this.userName;
+        return "";
+    }
+
+    public getCopyright(): string {
+        return this.copyright.join('\n');
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,7 +109,14 @@ class FileFactory {
 		this.copyright = this.processString(gConfig.getCopyright(), false, true);
 		let fullClassNameInput = await FileFactory.PrettyInputBox("Class name", "Enter class name (e.g. SomeClass / MyNamespace::MyOtherNamespace::SomeClass)");
 		if (fullClassNameInput === undefined) return;
+		
 		let fullClassName = String(fullClassNameInput);
+		const reNameValidator = /(?:(?:(?:[A-Za-z_]\w*)+::).*)?(?:[A-Za-z_]\w*)+/g
+		if (!reNameValidator.test(fullClassName)) {
+			vscode.window.showErrorMessage("C++ class geerator: invalid characters in class name");
+			return;
+		}
+
 		let namespaceSeparatorPos = fullClassName.lastIndexOf("::");
 		if (namespaceSeparatorPos != -1) {
 			this.namespaceName = fullClassName.slice(0, namespaceSeparatorPos);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,10 @@ import {
 	TextEncoder
 } from 'util';
 import * as vscode from 'vscode';
+import { Config } from './config';
 
 const gClock: Date = new Date();
+const gConfig: Config = new Config;
 
 interface FileTemplate {
 	string: string;
@@ -18,7 +20,6 @@ interface FileTemplate {
 
 class FileFactory {
 	private static encoder = new TextEncoder();
-	private static config = vscode.workspace.getConfiguration("cpp-class-generator");
 	private username: string = "User";
 	private copyright: string = "";
 	private namespaceName: string = "";
@@ -26,50 +27,8 @@ class FileFactory {
 	private headerName: string = "";
 	private sourceName: string = "";
 
-	private static UpdateConfig()
-	{
-		FileFactory.config = vscode.workspace.getConfiguration("cpp-class-generator");
-	}
-
-	private static getParameterFromConfig(name: string): unknown {
-		return FileFactory.config.get(name);
-	}
-
-	private static getStringParameterFromConfig(name: string): string {
-		let result = FileFactory.getParameterFromConfig(name);
-		if (result === null || result === undefined) return "";
-		return String(result);
-	}
-
-	private static async getTemplateFromConfig(name: string, templ = ""): Promise<FileTemplate> {
-		let result = FileFactory.getParameterFromConfig(name);
-		if (result === null || result === undefined) return { string: "", templ: templ };
-		if (Array.isArray(result)) {
-			if (templ.length != 0) return { string: "", templ: templ };
-			return { string: result.join('\n'), templ: templ };
-		}
-		let templates = new Map<string, Array<any>>(Object.entries(result as Object));
-		if (templ.length == 0) {
-			let templPick = await FileFactory.PrettyQuickPick(
-				Array.from(templates.keys()),
-				{
-					canPickMany: false,
-					title: "Choose class template",
-					placeHolder: "Template for class"
-				}
-			);
-			if (typeof templPick === 'string')
-				templ = templPick;
-			else
-				return { string: "", templ: templ };
-		}
-		let data = templates.get(templ);
-		if (data === null || data === undefined) return { string: "", templ: templ };
-		return { string: data.join('\n'), templ: templ };
-	}
-
 	private static getDate(): string {
-		let date: string = FileFactory.getStringParameterFromConfig("templates.date-format");
+		let date = gConfig.getDateFormat();
 		let yyyy = gClock.getFullYear().toString();
 		let yy = yyyy.slice(yyyy.length - 2);
 		let mm = (gClock.getMonth() + 1).toString().padStart(2, '0');
@@ -138,12 +97,16 @@ class FileFactory {
 	 * CreateFile
 	 */
 	public async CreateFile(path: vscode.Uri) {
-		FileFactory.UpdateConfig();
-		this.username = FileFactory.getStringParameterFromConfig("user.name");
+		let templates = await gConfig.getAvailableNames();
+		if (templates === undefined) {
+			vscode.window.showErrorMessage("C++ class geerator: no any template present");
+			return;
+		}
+		this.username = gConfig.getUserName();
 		if (this.username === "") {
 			this.username = userInfo().username;
 		}
-		this.copyright = this.processString((await FileFactory.getTemplateFromConfig("project.copyright")).string,false, true);
+		this.copyright = this.processString(gConfig.getCopyright(), false, true);
 		let fullClassNameInput = await FileFactory.PrettyInputBox("Class name", "Enter class name (e.g. SomeClass / MyNamespace::MyOtherNamespace::SomeClass)");
 		if (fullClassNameInput === undefined) return;
 		let fullClassName = String(fullClassNameInput);
@@ -157,53 +120,47 @@ class FileFactory {
 		const filenameInput = await FileFactory.PrettyInputBox("Filename", "Enter filename without extension", this.className);
 		if (filenameInput === undefined) return;
 		let filename = String(filenameInput);
-		let isSingleFilePick = await FileFactory.PrettyQuickPick(
-			["Default", "Separated Header/Source files", "Single file"],
+		let templPick = await FileFactory.PrettyQuickPick(
+			templates,
 			{
 				canPickMany: false,
-				title: "Choose which files will be created",
-				placeHolder: "One file or two files?"
+				title: "Choose class template",
+				placeHolder: "Template for class"
 			}
 		);
-		if ((isSingleFilePick === undefined) ||
-			(isSingleFilePick === "Default"))
-			isSingleFilePick = FileFactory.getStringParameterFromConfig("templates.default-file-scheme");
-		let isSingleFile = (isSingleFilePick === "Single file");
+		if (typeof templPick !== 'string')
+			return;
+		let template = await gConfig.getTemplate(templPick);
+		if (template === undefined) {
+			vscode.window.showErrorMessage("C++ class geerator: template is undefined");
+			return;
+		}
+		let isSingleFile = !Array.isArray(template.source);
 		let sourcePath = path.path;
 		if (sourcePath === "") return;
 
-		let headerExt = FileFactory.getStringParameterFromConfig("templates.header-extension");
-		let sourceExt = FileFactory.getStringParameterFromConfig("templates.source-extension");
-		let singleHeaderExt = FileFactory.getStringParameterFromConfig("templates.single-header-extension");
+		let headerExt = template.header_extension === undefined ? ".h" : template.header_extension;
+		let sourceExt = template.source_extension === undefined ? ".cpp" : template.source_extension;
+		let singleHeaderExt = template.header_extension === undefined ? ".hpp" : template.header_extension;
+		let headerFileTemplate = (template.header as Array<string>).join('\n');
 		this.sourceName = `${filename}${sourceExt}`;
 
 		// Create files
 		if (!isSingleFile) {
-			let headerFileTemplate = await FileFactory.getTemplateFromConfig("templates.header");
-			let sourceFileTemplate = await FileFactory.getTemplateFromConfig("templates.source", headerFileTemplate.templ);
-			if (headerFileTemplate.string.length == 0 || sourceFileTemplate.string.length == 0) {
-				vscode.window.showInformationMessage("C++ class not generated: invalid template");
-				return;
-			}
+			let sourceFileTemplate = (template.source as Array<string>).join('\n');
 			this.headerName = `${filename}${headerExt}`;
 			let headerfile = this.processString(
-				headerFileTemplate.string,
+				headerFileTemplate,
 				true);
 			FileFactory.ProcessFile(path.path, filename, headerExt, headerfile);
 			let sourcefile = this.processString(
-				sourceFileTemplate.string,
+				sourceFileTemplate,
 				false);
 			FileFactory.ProcessFile(path.path, filename, sourceExt, sourcefile);
 		} else {
 			this.headerName = `${filename}${singleHeaderExt}`;
-			let headerFileTemplate = await FileFactory.getTemplateFromConfig("templates.header-only");
-			if (headerFileTemplate.string.length == 0) headerFileTemplate = await FileFactory.getTemplateFromConfig("templates.header");
-			if (headerFileTemplate.string.length == 0) {
-				vscode.window.showInformationMessage("C++ class not generated: invalid template");
-				return;
-			}
 			let headerfile = this.processString(
-				headerFileTemplate.string,
+				headerFileTemplate,
 				true);
 			FileFactory.ProcessFile(path.path, filename, singleHeaderExt, headerfile);
 		}
@@ -219,7 +176,7 @@ export function activate(context: vscode.ExtensionContext) {
 		factory.CreateFile(path);
 	});
 
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(disposable, gConfig);
 }
 
 // this method is called when your extension is deactivated

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,0 +1,34 @@
+/**
+ * C++ class template
+ */
+export interface Template {
+    /**
+     * Header content or name of other template
+     */
+    header: string | Array<string>;
+
+    /**
+     * Source content or name of other template. When null class is single-header
+     */
+    source?: string | Array<string>;
+
+    /**
+     * Extension of header file. When null used .h for separated source/header classes and .hpp for single-header classes
+     */
+    header_extension?: string;
+
+    /**
+     * Extension of source file. When null used .cpp
+     */
+    source_extension?: string;
+}
+
+/**
+ * C++ class template
+ */
+export interface ConfigTemplate extends Template {
+    /**
+     * Name of class template
+     */
+    name: string;
+}


### PR DESCRIPTION
This PR aimed to simplify create multiple templates, and this changes most configurations:

### Templates

Next settings will be moved to `cpp-class-generator.templates` array.
- `cpp-class-generator.templates.header-extension`
- `cpp-class-generator.templates.single-header-extension`
- `cpp-class-generator.templates.source-extension`
- `cpp-class-generator.templates.header`
- `cpp-class-generator.templates.header-only`
- `cpp-class-generator.templates.source`

`cpp-class-generator.templates` - array with objects, to work VSCode autocompletion. Each object - template configuration:
```typescript
name: string; // required. Name of template
header: string | Array<string>; // required. Array with code or string with name of other template with code
source?: string | Array<string>; // optional. Array with code or string with name of other template with code
header_extension?: string; // optional. Header file extension, default value ".h"/".hpp"
source_extension?: string; // optional. Source file extension, default value ".cpp"
```

When config read, templates from global settings and workspace will be merged.

### Date format

Setting `cpp-class-generator.templates.date-format` changes to `cpp-class-generator.date-format`, to resolve conflicts with new templates settings.

### File schema

Setting `cpp-class-generator.templates.default-file-scheme` was removed, because this option now depended on template.

## Config example

```json
"cpp-class-generator.templates": [
    {
        "name": "Header-only class",
        "header": [
            "{copyright}",
            "",
            "#pragma once",
            "",
            "{namespaceStart}",
            "{namespaceTab}class {className} {",
            "{namespaceTab}};",
            "{namespaceEnd}"
        ]
    },
    {
        "name": "Separated source/header class",
        "header": "Header-only class", // Reference to header in other template
        "source": [
            "{copyright}",
            "",
            "#include \"{headerFileName}\"",
            ""
        ] 
    }
]
```

Now config read only when changed.


## Backward compatible

When old settings present, it automatically converted to new format