### PR TITLE
Add option to configure CMake, after create file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "eslint": "^8.18.0",
         "glob": "^8.0.3",
         "mocha": "^10.0.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "vscode-cmake-tools": "^1.0.0"
       },
       "engines": {
         "vscode": "^1.50.0"
@@ -2690,6 +2691,15 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
+    "node_modules/vscode-cmake-tools": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-cmake-tools/-/vscode-cmake-tools-1.0.0.tgz",
+      "integrity": "sha512-oZO+Ulo+OGaFuGQaPlNh+qDUWth0kmyz0d45Ws6KmqLGf1Q9gCOBct6jz7mAtzR/IqrCe/VV3O/CUmHfXpIZEA==",
+      "dev": true,
+      "engines": {
+        "vscode": "^1.63.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4671,6 +4681,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "vscode-cmake-tools": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-cmake-tools/-/vscode-cmake-tools-1.0.0.tgz",
+      "integrity": "sha512-oZO+Ulo+OGaFuGQaPlNh+qDUWth0kmyz0d45Ws6KmqLGf1Q9gCOBct6jz7mAtzR/IqrCe/VV3O/CUmHfXpIZEA==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,11 @@
               "header"
             ]
           }
+        },
+        "cpp-class-generator.cmake.configure": {
+          "type": "boolean",
+          "default": false,
+          "description": "Configure CMake project, after create class"
         }
       }
     }
@@ -165,6 +170,7 @@
     "eslint": "^8.18.0",
     "glob": "^8.0.3",
     "mocha": "^10.0.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "vscode-cmake-tools": "^1.0.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export class Config {
         "// Created by {userName} on {date} ",
         "//"
     ];
+    private cmakeConfigure: boolean = false;
 
     constructor() {
         this.reload();
@@ -32,6 +33,7 @@ export class Config {
         this.dateFormat = config.get('date-format', this.dateFormat);
         this.copyright = config.get<Array<string>>('project.copyright', this.copyright);
         this.userName = config.get('user.name', this.userName);
+        this.cmakeConfigure = config.get('cmake.configure', this.cmakeConfigure);
 
         this.templates.clear();
         // Merge global and local configs
@@ -237,5 +239,9 @@ export class Config {
 
     public getCopyright(): string {
         return this.copyright.join('\n');
+    }
+
+    public isNeedConfigureCmake(): boolean {
+        return this.cmakeConfigure;
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import {
 } from 'util';
 import * as vscode from 'vscode';
 import { Config } from './config';
+import * as api from 'vscode-cmake-tools';
 
 const gClock: Date = new Date();
 const gConfig: Config = new Config;
@@ -93,6 +94,17 @@ class FileFactory {
 		return Promise.resolve(pick);
 	}
 
+	private static async CmakeConfigure(uri: vscode.Uri) {
+		const workspace = vscode.workspace.getWorkspaceFolder(uri);
+		if (workspace === undefined) return;
+
+		api.getCMakeToolsApi(api.Version.v1).then(api => {
+			api?.getProject(workspace.uri).then(project => {
+				project?.configure();
+			});
+		});
+	}
+
 	/**
 	 * CreateFile
 	 */
@@ -171,6 +183,7 @@ class FileFactory {
 				true);
 			FileFactory.ProcessFile(path.path, filename, singleHeaderExt, headerfile);
 		}
+		if (gConfig.isNeedConfigureCmake()) FileFactory.CmakeConfigure(path);
 		vscode.window.showInformationMessage("C++ class generator: Done!");
 	}
 };


### PR DESCRIPTION
Partial resolve #5

[cmake-tools](https://github.com/microsoft/vscode-cmake-tools) don't provide API to work with `CMakeLists.txt` files, so we can't get information where sources defines in `CMakeLists.txt`, and we can't find right `CMakeLists.txt` without manual parsing workspace. But we can call configure for right project, so this PR allows adding generated classes in cmake for dirs, what included via `GLOB` or `aux_source_directory`.

By default, this behavior disabled (controlled by setting `cpp-class-generator.cmake.configure`)